### PR TITLE
feat(storage): delete stored files after draft is deleted

### DIFF
--- a/src/app/saveddrafts/page.tsx
+++ b/src/app/saveddrafts/page.tsx
@@ -10,6 +10,7 @@ import LoadingSpinner from "@components/LoadingSpinner";
 import DraftItem from "@components/DraftItem";
 import { fetchUsername } from "@lib/requests/fetchUsername";
 import { fetchPublishedDraftNumber } from "@lib/requests/fetchPublishedDraftNumber";
+import { deleteDraftStorage } from "@lib/requests/deleteDraftStorage";
 import DraftNameModal from "@components/DraftNameModal";
 import { ToastContainer } from "react-toastify";
 import { createTemplate } from "@lib/requests/admin/createTemplate";
@@ -143,6 +144,12 @@ export default function SavedDrafts() {
       const resBody = (await res.json()) as APIResponse<string>;
 
       if (res.ok && resBody.success) {
+        // Delete the Firebase Storage directory since draft is
+        // now successfully deleted
+        const user = auth.currentUser;
+        if (user) {
+          await deleteDraftStorage(user.uid, draftNumber);
+        }
         setDraftMappings((original) =>
           original.filter((d) => d.id !== draftNumber),
         );

--- a/src/lib/requests/deleteDraftStorage.ts
+++ b/src/lib/requests/deleteDraftStorage.ts
@@ -1,0 +1,19 @@
+import { getStorage, ref, listAll, deleteObject } from "firebase/storage";
+
+// Delete all files inside a Firebase Storage directory
+export const deleteDraftStorage = async (
+  userId: string,
+  draftNumber: number,
+) => {
+  const storage = getStorage();
+  const dirRef = ref(storage, `users/${userId}/drafts/${draftNumber}/`);
+
+  try {
+    const files = await listAll(dirRef);
+    const deletePromises = files.items.map((fileRef) => deleteObject(fileRef));
+
+    await Promise.all(deletePromises);
+  } catch (error) {
+    console.error("Error deleting draft storage:", error);
+  }
+};


### PR DESCRIPTION
actually delete the files stored in Firebase Storage for a specific draft (e.g., the files in `users/${userId}/drafts/${draftNumber}/` for draft number `${draftNumber}`) when the draft is deleted. 

that way, we're not storing files that are no longer accessible