### PR TITLE
fix(mobile preview): set isMobilePreview to false when exiting preview mode

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -559,7 +559,10 @@ export default function Editor() {
               </button>
               <button
                 className={`text-white text-large font-semibold px-3 py-2 rounded-md mr-1 bg-red-500 transition-all duration-300 hover:bg-red-700 shadow-md hover:shadow-lg fixed top-[10px] right-[0px] z-[1000]`}
-                onClick={() => setIsPreview(!isPreview)}
+                onClick={() => {
+                  setIsPreview(!isPreview);
+                  setIsMobilePreview(false);
+                }}
               >
                 Exit Preview
               </button>


### PR DESCRIPTION
There was a bug where if the user exits preview mode while in mobile preview mode, their project cards would still be formatted vertically in the editor.

![image](https://github.com/user-attachments/assets/6b168754-0b68-49ef-a557-67725e4cd031)
