### PR TITLE
fix(mobile preview): make mobile overlay responsive to different screen sizes

### DIFF
--- a/src/components/FullWindow.tsx
+++ b/src/components/FullWindow.tsx
@@ -45,8 +45,8 @@ export default function FullWindow({
       <div
         className="bg-white border-[5px] border-black rounded-md shadow-lg mx-auto mt-16"
         style={{
-          width: "375px",
-          height: "667px",
+          width: "44.97vh",
+          height: "80vh",
           overflow: "auto",
           position: "relative",
         }}

--- a/src/components/editorComponents/NavigationBar.tsx
+++ b/src/components/editorComponents/NavigationBar.tsx
@@ -151,7 +151,7 @@ export default function NavigationBar({
       <div
         className={`bg-gray-800 text-white shadow-lg z-[100] overflow-x-hidden ${
           isPreview
-            ? "fixed top-[calc(4rem+5px)] left-1/2 w-[365px] -translate-x-1/2"
+            ? "fixed top-[calc(4rem+5px)] left-1/2 w-[calc(44.97vh_-_5px)] -translate-x-1/2"
             : "fixed top-0 left-0 w-screen"
         }`}
       >


### PR DESCRIPTION
Navbar overlay is currently fixed, causing visual bug when scrolling: 
![image](https://github.com/user-attachments/assets/12199c91-68f7-422b-816c-42a3cd2fd3d2)
Made mobile preview responsive to different screen sizes to remove need to scroll