### PR TITLE
feat(upload): limit image uploads to 5MB

### DIFF
--- a/src/components/editorComponents/AboutMeCard.tsx
+++ b/src/components/editorComponents/AboutMeCard.tsx
@@ -7,6 +7,7 @@ import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
 import { useSearchParams } from "next/navigation";
 
 import ActiveOutlineContainer from "@components/editorComponents/ActiveOutlineContainer";
+import { toastError } from "@components/toasts/ErrorToast";
 
 import type {
   ComponentItem,
@@ -15,7 +16,7 @@ import type {
 } from "@customTypes/componentTypes";
 
 import { handleDragStop, handleResizeStop } from "@utils/dragResizeUtils";
-import { GRID_SIZE } from "@utils/constants";
+import { GRID_SIZE, MAX_FILE_SIZE } from "@utils/constants";
 import { auth, storage } from "@lib/firebase/firebaseApp";
 
 interface AboutMeCardContent {
@@ -107,6 +108,11 @@ export default function AboutMeCard({
 
     if (e.target.files && e.target.files[0]) {
       const file = e.target.files[0];
+      if (file.size > MAX_FILE_SIZE) {
+        toastError("Image size exceeds the 5MB limit. Please upload a smaller image.");
+        return;
+      }
+
       const filePath = `users/${userId}/drafts/${draftNumber}/${id}-${file.name}`;
 
       const storageRef = ref(storage, filePath);
@@ -206,7 +212,6 @@ export default function AboutMeCard({
         <p
           draggable="false"
           className="overflow-hidden min-w-[300px] max-w-[300px] max-h-[60px] flex-grow text-black cursor-text p-0 m-0 leading-none rounded-sm"
-       
        >
           {curContent.bio}
         </p>

--- a/src/components/editorComponents/FileComponent.tsx
+++ b/src/components/editorComponents/FileComponent.tsx
@@ -16,7 +16,7 @@ import type {
   Size,
 } from "@customTypes/componentTypes";
 import { handleDragStop, handleResizeStop } from "@utils/dragResizeUtils";
-import { GRID_SIZE } from "@utils/constants";
+import { GRID_SIZE, MAX_FILE_SIZE } from "@utils/constants";
 import { auth, storage } from "@lib/firebase/firebaseApp";
 
 interface FileComponentProps {
@@ -57,9 +57,6 @@ export default function FileComponent({
   const [showOverlay, setShowOverlay] = useState(false);
 
   const draftNumber = useSearchParams().get("draftNumber");
-
-  // https://stackoverflow.com/questions/58488416/open-base64-encoded-pdf-file-using-javascript-issue-with-file-size-larger-than
-  const MAX_FILE_SIZE = 5 * 1024 * 1025; // max 5MB upload for now
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const userId = auth.currentUser?.uid;

--- a/src/components/editorComponents/ImageComponent.tsx
+++ b/src/components/editorComponents/ImageComponent.tsx
@@ -7,6 +7,7 @@ import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
 import { useSearchParams } from "next/navigation";
 
 import ActiveOutlineContainer from "@components/editorComponents/ActiveOutlineContainer";
+import { toastError } from "@components/toasts/ErrorToast";
 import SkeletonLoader from "@components/editorComponents/SkeletonLoader";
 
 import type {
@@ -15,7 +16,7 @@ import type {
   Size,
 } from "@customTypes/componentTypes";
 import { handleDragStop, handleResizeStop } from "@utils/dragResizeUtils";
-import { GRID_SIZE } from "@utils/constants";
+import { GRID_SIZE, MAX_FILE_SIZE } from "@utils/constants";
 import { auth, storage } from "@lib/firebase/firebaseApp";
 
 interface ImageComponentProps {
@@ -82,6 +83,11 @@ export default function ImageComponent({
 
     if (e.target.files && e.target.files[0]) {
       const file = e.target.files[0];
+      if (file.size > MAX_FILE_SIZE) {
+        toastError("Image size exceeds the 5MB limit. Please upload a smaller image.");
+        return;
+      }
+
       const filePath = `users/${userId}/drafts/${draftNumber}/${id}-${file.name}`;
       const storageRef = ref(storage, filePath);
       const uploadTask = uploadBytesResumable(storageRef, file);

--- a/src/components/editorComponents/ProjectCard/ImageCard.tsx
+++ b/src/components/editorComponents/ProjectCard/ImageCard.tsx
@@ -5,8 +5,10 @@ import { useState, useRef, useLayoutEffect } from "react";
 import { Rnd } from "react-rnd";
 import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
 
+import { toastError } from "@components/toasts/ErrorToast";
+
 import { auth, storage } from "@lib/firebase/firebaseApp";
-import { GRID_SIZE } from "@utils/constants";
+import { GRID_SIZE, MAX_FILE_SIZE } from "@utils/constants";
 
 interface ImageCardProps {
   cardId: number;
@@ -59,6 +61,10 @@ export default function ImageCard({
   const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    if (file.size > MAX_FILE_SIZE) {
+      toastError("Image size exceeds the 5MB limit. Please upload a smaller image.");
+      return;
+    }
 
     const userId = auth.currentUser?.uid;
     const filePath = `users/${userId}/drafts/${draftNumber}/${cardId}-${file.name}`;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,2 @@
 export const GRID_SIZE = 10;
+export const MAX_FILE_SIZE = 5 * 1024 * 1025; // max 5MB upload for now


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/98118d41-990f-4688-aef8-9167f9bd9cfc)

added image upload limit of 5MB to AboutMe, Image, and ProjectCard components.