### PR TITLE
fix(richtext): fix outline showing for boxes with lists in preview

### DIFF
--- a/src/components/editorComponents/DraggableResizableTextbox.tsx
+++ b/src/components/editorComponents/DraggableResizableTextbox.tsx
@@ -98,10 +98,7 @@ export default function DraggableResizableTextbox({
     >
       <LexicalComposer initialConfig={RichTextInitialConfig}>
         <div
-          className={`w-full h-full transition-all duration-150 ease-in-out rounded ${isActive
-              ? "outline outline-2 outline-blue-500 shadow-md"
-              : "outline outline-2 outline-transparent hover:outline hover:outline-2 hover:outline-gray-300"
-            }`}
+          className={"w-full h-full transition-all duration-150 ease-in-out rounded"}
           style={{ backgroundColor: data.backgroundColor || "transparent" }}
         >
           <RichTextbox


### PR DESCRIPTION
For rich text boxes with lists, an outline shows
<img width="1336" alt="image" src="https://github.com/user-attachments/assets/758f9ffd-813a-4909-adc5-e84548acb2aa" />

Fix:
<img width="1206" alt="image" src="https://github.com/user-attachments/assets/2a9ee8fc-ebe0-43c5-bf17-a2e6b81a11a4" />

