### PR TITLE
fix(links): prevent link editor from going off screen

### DIFF
--- a/src/components/RichText/Plugins/RichTextLinks.tsx
+++ b/src/components/RichText/Plugins/RichTextLinks.tsx
@@ -101,15 +101,22 @@ export default function RichTextLinks({
               if (element && dropzone) {
                 const elementRect = element.getBoundingClientRect();
                 const dropzoneRect = dropzone.getBoundingClientRect();
+
+                // When text wraps, the element.offsetLeft property doesn't return
+                // the leftmost edge
+                // The elementRect.left property does return the leftmost edge
+                const offsetParent = element.offsetParent
+                const trueOffsetLeft = elementRect.left - offsetParent!.getBoundingClientRect().left;
+
                 if (elementRect.left + linkEditorWidth > dropzoneRect.right) {
+                  const overflowX = (elementRect.left + linkEditorWidth) - dropzoneRect.right;
                   setLinkEditorPosition({
-                    x:
-                      dropzoneRect.right - (elementRect.left + linkEditorWidth),
+                    x: trueOffsetLeft - overflowX,
                     y: element.offsetTop + element.offsetHeight + 4,
                   });
                 } else {
                   setLinkEditorPosition({
-                    x: element.offsetLeft,
+                    x: trueOffsetLeft,
                     y: element.offsetTop + element.offsetHeight + 4,
                   });
                 }
@@ -281,7 +288,7 @@ export default function RichTextLinks({
           }}
           onKeyUp={(e) => {
             // Enter key pressed
-            if (e.key === "Enter" || e.keyCode === 13) {
+            if (e.key === "Enter") {
               updateLink();
             }
           }}
@@ -299,7 +306,7 @@ export default function RichTextLinks({
           }}
           onKeyUp={(e) => {
             // Enter key is pressed
-            if (e.key === "Enter" || e.keyCode === 13) {
+            if (e.key === "Enter") {
               updateLink();
             }
           }}


### PR DESCRIPTION
Prevent link editor from going off screen

Text block:
<img width="1919" alt="image" src="https://github.com/user-attachments/assets/d6c1999a-6c9f-4644-8e81-944c97ac960d" />

Section title:
<img width="1915" alt="image" src="https://github.com/user-attachments/assets/7b2ca94b-d8db-4437-ab28-5407e6146677" />

Project card:
<img width="1919" alt="image" src="https://github.com/user-attachments/assets/5760f8ec-d14d-4c4c-b3b2-d1e03f1e787e" />
