### PR TITLE
fix(editor): prevent sidebar from overlapping with editor when browse…

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -634,9 +634,9 @@ export default function Editor() {
                   ref={scrollContainerRef}
                   style={{
                     marginTop: "64px",
-                    marginLeft: "256px",
+                    marginLeft: "16rem",
                     height: `calc(100vh - 64px)`, // full height minus top bar
-                    width: `calc(100vw - 256px)`, // full width minus sidebar
+                    width: `calc(100vw - 16rem)`, // full width minus sidebar
                   }}
                 >
                   <EditorDropZone

--- a/src/components/editorComponents/EditorTopBar.tsx
+++ b/src/components/editorComponents/EditorTopBar.tsx
@@ -19,7 +19,7 @@ export default function EditorTopBar({
   handlePublish,
 }: EditorTopBarProps) {
   return (
-    <div className="fixed top-0 left-[256px] w-[calc(100vw-256px)] z-50 bg-gray-100 flex justify-between items-center px-6 py-3 h-[64px]">
+    <div className="fixed top-0 left-[16rem] w-[calc(100vw-16rem)] z-50 bg-gray-100 flex justify-between items-center px-6 py-3 h-[64px]">
       <div className="flex items-center gap-10">
         <Link
           href="/saveddrafts"


### PR DESCRIPTION
Fix sidebar overlapping with the rest of the editor when the browser has different font sizes

Very small
<img width="1909" alt="image" src="https://github.com/user-attachments/assets/6a70fa18-f8f9-4789-9b50-e53487ef6850" />

Small
<img width="1908" alt="image" src="https://github.com/user-attachments/assets/425b9ad9-9696-4ce7-b908-162031f42874" />

Medium (default)
<img width="1908" alt="image" src="https://github.com/user-attachments/assets/476063f5-3010-4e3b-b801-513ae7409cc4" />

Large
<img width="1894" alt="image" src="https://github.com/user-attachments/assets/332a9b6a-4df2-411d-aec2-71f2b6634018" />

Very large
<img width="1895" alt="image" src="https://github.com/user-attachments/assets/21cdcd1a-cd41-4074-ab28-bfe0f700a52d" />
