### PR TITLE
fix(sidebar): make drag overlay's max drag distance not dependent on initial click

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -584,7 +584,7 @@ export default function Editor() {
         <PagesContextProvider pages={pages}>
           <EditorContextProvider handleSwitchPage={handleSwitchPage}>
             <DndContext
-              modifiers={[restrictToWindowEdges, snapCenterToCursor]}
+              modifiers={[snapCenterToCursor]}
               onDragStart={handleDragStart}
               onDragEnd={handleDragEnd}
               onDragMove={handleDragMove}
@@ -718,7 +718,10 @@ export default function Editor() {
                   <ArrowUpIcon size={24} />
                 </button>
               )}
-              <DragOverlay className="z-[10000]">
+              <DragOverlay
+                className="z-[10000]"
+                modifiers={[restrictToWindowEdges]}
+              >
                 {renderOverlayContent(activeComponent?.type || null)}
               </DragOverlay>
             </DndContext>


### PR DESCRIPTION
The `snapCenterToCursor` modifier interacts strangely with the `restrictToWindowEdges` modifier when they're both on the DndContext element. Depending on where the sidebar item initially gets clicked, the window edges are different.

e.g. if you click on the far left of a sidebar item, you can't drag it to the right most edge of the window and you can drag it past the left most edge of the window.

Moving `restrictToWindowEdges` onto the DragOverlay component solves the issue.