### PR TITLE
feat(richtext): allow links that dont have protocol

### DIFF
--- a/src/components/RichText/Plugins/RichTextLinks.tsx
+++ b/src/components/RichText/Plugins/RichTextLinks.tsx
@@ -243,10 +243,8 @@ export default function RichTextLinks({
   };
 
   const updateLink = () => {
-    if (
-      getPageIdx(linkEditorURLField) !== -1 ||
-      isValidURL(linkEditorURLField)
-    ) {
+    const validatedURL = isValidURL(linkEditorURLField);
+    if (getPageIdx(linkEditorURLField) !== -1 || validatedURL) {
       setIsLinkEditorVisible(false);
       setEscapePressed(true);
 
@@ -260,7 +258,7 @@ export default function RichTextLinks({
             setLastActiveLinkNodeKey(linkParent.getKey());
 
             // Replace the old link with a new link node containing the entered fields
-            const newLink = $createLinkNode(linkEditorURLField);
+            const newLink = $createLinkNode(validatedURL);
             newLink.append($createTextNode(linkEditorTextField));
 
             linkParent.replace(newLink);

--- a/src/components/RichText/utils/isValidURL.ts
+++ b/src/components/RichText/utils/isValidURL.ts
@@ -14,14 +14,17 @@ export default function isValidURL(url: string): string {
     const parsedURL = new URL(url);
     if (!SUPPORTED_URL_PROTOCOLS.has(parsedURL.protocol)) {
       toastError(
-        "Selected text must include one of the following protocols: http, https, mailto, sms, tel.",
+        "Unsupported URL protocol. Only http, https, mailto, sms, and tel are allowed when a protocol is included.",
       );
       return "";
     }
   } catch {
-    toastError(
-      "Selected text is not a valid URL. Ensure that a protocol is provided. Example: https://example.com",
-    );
+    // Fallback: allow domain only URLs with optional path and query
+    const domainOnlyRegExp = /^[a-z0-9.-]+\.[a-z]{2,}(?::\d+)?(\/[^\s]*)?$/i;
+    if (domainOnlyRegExp.test(url)) {
+      return `https://${url}`;
+    }
+    toastError("Selected text is not a valid URL.");
     return "";
   }
 


### PR DESCRIPTION
allow for urls like `example.com` to also be used instead of just having `https://example.com`