### PR TITLE
fix(image): make link menu not go offscreen

### DIFF
--- a/src/components/editorComponents/ImageComponent.tsx
+++ b/src/components/editorComponents/ImageComponent.tsx
@@ -162,6 +162,12 @@ export default function ImageComponent({
     }
   };
 
+  const dropdownWidth = 323;
+  const parentWidth =
+    document.getElementById("editor-drop-zone")?.clientWidth || 500;
+
+  const isButtonOnLeft = position.x + dropdownWidth > parentWidth;
+
   return isPreview ? (
     <div
       style={{
@@ -337,7 +343,7 @@ export default function ImageComponent({
           style={{
             position: "absolute",
             top: `${position.y + size.height + 10}px`,
-            left: `${position.x}px`,
+            left: `${isLinkEditing && isButtonOnLeft ? position.x - dropdownWidth + size.width : position.x}px`,
             zIndex: 10,
             pointerEvents: "auto",
             transition: "opacity 0.2s ease-in-out, transform 0.1s",


### PR DESCRIPTION
when it is on the right edge, the link menu will now be pushed to the left
![image](https://github.com/user-attachments/assets/dde456e3-1f87-4a06-a3c6-7d6e8f21fc82)


default behavior:
![image](https://github.com/user-attachments/assets/0ea99d35-44e4-401a-9398-afee18d28a4f)

