### PR TITLE
Fix scroll and about me cards

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -423,13 +423,8 @@ export default function Editor() {
           editorBounds.width - draggedRect.width,
         ),
       );
-      const dropY = Math.max(
-        0,
-        Math.min(
-          draggedRect.top - editorBounds.top,
-          editorBounds.height - draggedRect.height,
-        ),
-      );
+
+      const dropY = Math.max(0, draggedRect.top - editorBounds.top);
 
       let roundedX = Math.round(dropX / GRID_SIZE) * GRID_SIZE;
       const roundedY = Math.round(dropY / GRID_SIZE) * GRID_SIZE;
@@ -458,6 +453,7 @@ export default function Editor() {
         ...components.map((comp) => comp.position.y + comp.size.height),
         newPos.y + newSize.height,
       );
+
       setEditorHeight(Math.max(lowestY + 100, window.innerHeight - 64));
     }
   };
@@ -466,9 +462,9 @@ export default function Editor() {
     if (!editorRef.current) return;
 
     const editorRect = editorRef.current.getBoundingClientRect();
-    const cursorY = active.rect.current.translated?.top ?? 0;
+    const cursorY = active.rect.current.translated?.bottom ?? 0;
 
-    if (cursorY > editorRect.bottom - 100) {
+    if (cursorY >= editorRect.bottom - 10) {
       setEditorHeight((prevHeight) => prevHeight + 50);
     }
   };

--- a/src/components/editorComponents/AboutMeCard.tsx
+++ b/src/components/editorComponents/AboutMeCard.tsx
@@ -215,7 +215,8 @@ export default function AboutMeCard({
     } catch (err) {
       console.error("Failed to parse content for AboutMeCard:", err);
     }
-  }, [content]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleMouseDown = (e: MouseEvent) => {
     e.stopPropagation();
@@ -491,6 +492,7 @@ export default function AboutMeCard({
                           />
                         ) : imageUrl ? (
                           <img
+                            draggable={false}
                             src={imageUrl}
                             alt="Uploaded"
                             className="w-full h-full object-cover"

--- a/src/components/editorComponents/AboutMeCard.tsx
+++ b/src/components/editorComponents/AboutMeCard.tsx
@@ -186,6 +186,7 @@ export default function AboutMeCard({
   const [showOverlay, setShowOverlay] = useState(false);
   const imageContainerRef = useRef<HTMLDivElement>(null);
   const [parentSize, setParentSize] = useState({ width: 1, height: 1 });
+  const imgRef = useRef(null);
 
   const draftNumber = useSearchParams().get("draftNumber");
 
@@ -299,6 +300,54 @@ export default function AboutMeCard({
     );
   };
 
+  const updateImagePercents = () => {
+    const imgContainer = imageContainerRef.current! as HTMLElement;
+    const imgContainerRect = imgContainer.getBoundingClientRect();
+
+    const img = imgRef.current! as HTMLElement;
+    const imgRect = img.getBoundingClientRect();
+
+    const imgOffsetXFromParent = imgRect.left - imgContainerRect.left;
+    const imgOffsetYFromParent = imgRect.top - imgContainerRect.top;
+
+    const distToContainerRightEdge =
+      imgContainerRect.width - imgOffsetXFromParent;
+
+    // Max %width image can be before it overflows horizontally
+    const maxPercentWidthForHoriz =
+      distToContainerRightEdge / imgContainerRect.width;
+
+    // Max %width image can be before it overflows vertically
+    const maxPercentWidthForVert =
+      (imgRect.width * (imgContainerRect.height - imgOffsetYFromParent)) /
+      (imgContainerRect.width * imgRect.height);
+
+    // Multiplied by 100 for unit conversion, i.e. 10% ==> 10.0
+    const maxPercentWidth =
+      Math.min(maxPercentWidthForHoriz, maxPercentWidthForVert) * 100;
+
+    // Min width is 100px
+    // Multiplied by 100 for unit conversion, i.e. 10% ==> 10.0
+    const minPercentWidth = (100 / imgContainerRect.width) * 100;
+
+    // New width is bounded between [minPercentWidth, maxPercentWidth]
+    const newWidthPercent = Math.max(
+      minPercentWidth,
+      Math.min(imageWidthPercent, maxPercentWidth),
+    );
+    setImageWidthPercent(newWidthPercent);
+
+    // Overflow right
+    if (distToContainerRightEdge < imgRect.width) {
+      const newWidth = (newWidthPercent / 100) * imgContainerRect.width;
+      const newOffsetXFromParent = imgContainerRect.width - newWidth;
+      const newPosXPercent = newOffsetXFromParent / imgContainerRect.width;
+      setImagePositionPercent((prev) => {
+        return { ...prev, x: newPosXPercent * 100 };
+      });
+    }
+  };
+
   return isPreview ? (
     <div
       style={{
@@ -381,7 +430,17 @@ export default function AboutMeCard({
             setPosition,
           )(e, d);
         }}
-        onResizeStart={() => setIsDragging(true)}
+        onResize={(_, __, ref, ___, ____) => {
+          // Force children to update/re-render: this prevents the image from snapping
+          // into position after the resize event stops
+          const rect = ref.getBoundingClientRect();
+          setSize({ width: rect.width, height: rect.height });
+
+          updateImagePercents();
+        }}
+        onResizeStart={() => {
+          setIsDragging(true);
+        }}
         onResizeStop={(e, d, ref, delta, newPosition) => {
           setIsDragging(false);
           handleResizeStop(
@@ -483,7 +542,10 @@ export default function AboutMeCard({
                       enableResizing={isActive}
                       onMouseDown={(e) => e.stopPropagation()}
                     >
-                      <div className="w-full h-full flex items-center justify-center bg-gray-200 cursor-pointer">
+                      <div
+                        ref={imgRef}
+                        className="w-full h-full flex items-center justify-center bg-gray-200 cursor-pointer"
+                      >
                         {previewSrc ? (
                           <img
                             src={previewSrc}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -149,17 +149,17 @@ const categorizedItems = {
 
 export default function Sidebar() {
   return (
-    <div className="flex w-64 bg-gray-100 max-h-screen fixed left-0 top-0 transition-width duration-300">
-      <div className="overflow-y-auto w-64 bg-gray-100 px-4 pt-3 pb-4 border-r h-screen">
-        <Link href="/" className="flex items-center gap-x-3 mb-4">
+    <div className="flex flex-col w-64 bg-gray-100 max-h-screen fixed left-0 top-0 transition-width duration-300">
+      <div className="sticky flex justify-center items-center min-h-[64px]">
+        <Link href="/" className="flex gap-x-3 items-center">
           <Image src="/logo.png" width={32} height={32} alt="Profesite Logo" />
           <span className="self-center text-4xl font-light tracking-wide whitespace-nowrap iceland-font">
             PROFESITE
           </span>
         </Link>
-
+      </div>
+      <div className="overflow-y-auto w-64 bg-gray-100 px-4 pt-3 pb-4 border-r h-screen">
         <h1 className="text-lg font-bold mb-4">Components</h1>
-
         <Accordion>
           {Object.entries(categorizedItems).map(([category, items]) => (
             <AccordionItem key={category} title={category}>


### PR DESCRIPTION
Fixed about me card not expanding the page vertically when being dragged in. Also made made dropping components into the page more consistent when expanding the page vertically. While the page was expanding, there was a bug where placing components would make them to get placed in a location that was different from where it was initially dropped (usually snapping upwards). This didn't happen all the time and seemed to happen randomly, so I'm guessing it was due to state variables being updated asynchronously (?).

Made Profesite logo stay at the top of the sidebar when scrolling
<img width="255" alt="image" src="https://github.com/user-attachments/assets/b7a889ab-83cb-4c1b-b6a4-f2301b7b90e4" />

Math for keeping the image inside its container for about me cards:
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/6b68af98-4475-409b-b323-fac4eea85401" />
