### PR TITLE
Style

### DIFF
--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -63,9 +63,9 @@ export default function Help() {
           />
         )}
       </header>
-      <div className="w-screen h-screen overflow-hidden flex justify-center items-center">
+      <div className="h-screen overflow-hidden flex justify-center items-center border">
         <iframe
-          className="w-[80vw] max-w-[816px] h-[90vh]"
+          className="w-full md:w-[90vw] max-w-[816px] h-[90vh] overflow-x-hidden border rounded-lg bg-white"
           src="https://docs.google.com/document/d/e/2PACX-1vS0GWDSRMe_pjCnsHMh9RHMAyX_LFmUVtr4Y4YBu7g3acB555zxMAM_lNCTMJtiwGGFWuU4Xw6ol0gM/pub?embedded=true"
         ></iframe>
       </div>

--- a/src/components/sidebar/SidebarItem.tsx
+++ b/src/components/sidebar/SidebarItem.tsx
@@ -35,7 +35,7 @@ export default function SidebarItem({
       {...listeners}
       {...attributes}
       style={style}
-      className="flex items-start gap-3 px-3 py-4 bg-white hover:bg-blue-100 rounded-lg hover:shadow-md hover:scale-[1.01] transform transition-all cursor-grab active:cursor-grabbing hover:border hover:border-gray-300"
+      className="flex items-start gap-3 px-3 py-4 bg-white hover:bg-blue-100 rounded-lg hover:shadow-md hover:scale-[1.01] transform transition-all cursor-grab active:cursor-grabbing outline-1 outline-transparent hover:outline hover:outline-gray-300"
     >
       <div className="text-blue-500">{icon}</div>
       <div>


### PR DESCRIPTION
Make help page more mobile friendly
<img width="386" alt="image" src="https://github.com/user-attachments/assets/5417fd65-8bc7-43ab-af0a-14232ab81b12" />

Stop text from wrapping when hovering over an item in the editor's sidebar