### PR TITLE
fix(links): fix relative links being treated as invalid URLs

### DIFF
--- a/src/components/RichText/Plugins/RichTextLinks.tsx
+++ b/src/components/RichText/Plugins/RichTextLinks.tsx
@@ -243,30 +243,37 @@ export default function RichTextLinks({
   };
 
   const updateLink = () => {
-    const validatedURL = isValidURL(linkEditorURLField);
-    if (getPageIdx(linkEditorURLField) !== -1 || validatedURL) {
-      setIsLinkEditorVisible(false);
-      setEscapePressed(true);
-
-      editor.update(() => {
-        const selection = $getSelection();
-        if ($isRangeSelection(selection)) {
-          const node = getSelectedNode(selection);
-          const linkParent = $findMatchingParent(node, $isLinkNode);
-
-          if (linkParent) {
-            setLastActiveLinkNodeKey(linkParent.getKey());
-
-            // Replace the old link with a new link node containing the entered fields
-            const newLink = $createLinkNode(validatedURL);
-            newLink.append($createTextNode(linkEditorTextField));
-
-            linkParent.replace(newLink);
-            newLink.select(0);
-          }
-        }
-      });
+    let validatedURL = "";
+    if (getPageIdx(linkEditorURLField) !== -1) {
+      validatedURL = linkEditorURLField;
+    } else {
+      validatedURL = isValidURL(linkEditorURLField);
+      if (validatedURL === "") {
+        return;
+      }
     }
+
+    setIsLinkEditorVisible(false);
+    setEscapePressed(true);
+
+    editor.update(() => {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        const node = getSelectedNode(selection);
+        const linkParent = $findMatchingParent(node, $isLinkNode);
+
+        if (linkParent) {
+          setLastActiveLinkNodeKey(linkParent.getKey());
+
+          // Replace the old link with a new link node containing the entered fields
+          const newLink = $createLinkNode(validatedURL);
+          newLink.append($createTextNode(linkEditorTextField));
+
+          linkParent.replace(newLink);
+          newLink.select(0);
+        }
+      }
+    });
   };
 
   return (


### PR DESCRIPTION
Changed the order of how links were validated in rich text components.

Now, the input gets checked to see if it's a relative link first. Then, if it isn't a relative link, it'll check whether or not it's a valid, general URL. Before, the isValidURL function would be executed first, causing an error toast to pop up. This was a problem for relative links since they're not intended to be valid URLs.